### PR TITLE
Add remember_me login flag

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -56,7 +56,15 @@ API Documentation will be available at http://localhost:8000/docs.
 ## API Endpoints
 
 ### Authentication
-- `POST /api/v1/auth/login` - Login to get a JWT token
+- `POST /api/v1/auth/login` - Login to get a JWT token (accepts optional `remember_me` boolean)
+
+#### Example
+
+```bash
+curl -X POST http://localhost:8000/api/v1/auth/login \
+     -d "username=myuser&password=mypass&remember_me=true" \
+     -H "Content-Type: application/x-www-form-urlencoded"
+```
 
 ### Users
 - `POST /api/v1/users/` - Register a new user

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -21,21 +21,39 @@ router = APIRouter()
 
 @router.post("/login", response_model=Token)
 async def login(
+    request: Request,
     db: Session = Depends(get_db),
     form_data: OAuth2PasswordRequestForm = Depends()
 ) -> Any:
     """
     OAuth2 compatible token login, get an access token for future requests.
     """
-    user = authenticate_user(db, form_data.username, form_data.password)
+    remember_me = False
+    username = form_data.username
+    password = form_data.password
+
+    if request.headers.get("Content-Type", "").startswith("application/json"):
+        body = await request.json()
+        username = body.get("username", username)
+        password = body.get("password", password)
+        remember_me = body.get("remember_me", False)
+    else:
+        form = await request.form()
+        remember_me_value = form.get("remember_me")
+        if remember_me_value is not None:
+            remember_me = str(remember_me_value).lower() in ("true", "1", "on", "yes")
+
+    user = authenticate_user(db, username, password)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    access_token_expires = timedelta(
-        minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
+    access_token_expires = (
+        timedelta(days=30)
+        if remember_me
+        else timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     access_token = create_access_token(
         data={"sub": user.username}, expires_delta=access_token_expires

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -43,7 +43,7 @@ export function LoginForm() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     try {
-      await authApi.login(values.username, values.password);
+      await authApi.login(values.username, values.password, values.rememberMe);
       
       // Jeśli użytkownik wybrał "Zapamiętaj mnie", ustaw dłuższą sesję
       if (values.rememberMe) {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -157,10 +157,13 @@ apiClient.interceptors.response.use(
 
 // Auth API
 export const authApi = {
-  login: async (username: string, password: string) => {
+  login: async (username: string, password: string, rememberMe?: boolean) => {
     const params = new URLSearchParams();
     params.append("username", username);
     params.append("password", password);
+    if (rememberMe !== undefined) {
+      params.append("remember_me", String(rememberMe));
+    }
     
     try {
       const response = await apiClient.post(`/auth/login`, params, {


### PR DESCRIPTION
## Summary
- support `remember_me` flag in login API call
- pass `rememberMe` from login form
- handle optional `remember_me` on backend to extend expiration to 30 days
- document new parameter and example in backend README

## Testing
- `npm run lint` *(fails: many lint errors)*
- `pytest -q` *(fails: async test plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_688292f204008325bdacf1d1bfc008b5