### PR TITLE
Remove unused loading flag in login page

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import Image from "next/image";
-import { redirect } from "next/navigation";
-import { useEffect, useState } from "react";
 import { LoginForm } from "@/components/auth/login-form";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { authApi } from "@/lib/api-client";
 import { Toaster } from "@/components/ui/sonner";
 
 export default function LoginPage() {
-  const [isLoading, setIsLoading] = useState(true);
 
   // Add logic to check for redirect after successful login
   const handleLoginSuccess = () => {


### PR DESCRIPTION
## Summary
- clean up imports and remove unused state from the login page

## Testing
- `npm run lint` *(fails: multiple lint errors in repository)*
- `pytest -q` *(fails: async tests require extra plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6882930cd2248325ba21e698db26766c