### PR TITLE
Implement logout endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -57,6 +57,7 @@ API Documentation will be available at http://localhost:8000/docs.
 
 ### Authentication
 - `POST /api/v1/auth/login` - Login to get a JWT token
+- `POST /api/v1/auth/logout` - Clear authentication cookies and logout
 
 ### Users
 - `POST /api/v1/users/` - Register a new user

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Response
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
@@ -41,6 +41,15 @@ async def login(
         data={"sub": user.username}, expires_delta=access_token_expires
     )
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/logout")
+async def logout(response: Response) -> Any:
+    """Clear authentication cookies and log out user."""
+    response.delete_cookie("auth_token")
+    response.delete_cookie("access_token")
+    response.delete_cookie("Authorization")
+    return {"detail": "Logged out"}
 
 
 @router.post("/cli-login", response_model=Token)

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -182,11 +182,8 @@ export const authApi = {
   
   async logout() {
     try {
-      // Najpierw próbujemy wywołać endpoint wylogowania po stronie serwera
-      await fetch('/auth/logout', {
-        method: 'POST',
-        credentials: 'include', // ważne aby wysłać cookies
-      });
+      // Call backend logout to clear any cookie based tokens
+      await apiClient.post('/auth/logout');
     } catch (error) {
       console.error('Backend logout failed:', error);
     }


### PR DESCRIPTION
## Summary
- add `/auth/logout` endpoint to remove cookies
- add docs for logout endpoint
- call new endpoint from `authApi.logout`

## Testing
- `pip install -r backend/requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68829323e900832595145c96ba11de27