### PR TITLE
Add WebSocket verification handling

### DIFF
--- a/backend/app/websocket/routes.py
+++ b/backend/app/websocket/routes.py
@@ -6,6 +6,8 @@ from app.db.session import get_db
 from sqlalchemy.orm import Session
 from typing import Optional
 import json
+import random
+import string
 
 router = APIRouter(prefix="/ws", tags=["websockets"])
 
@@ -64,6 +66,15 @@ async def job_status_websocket(
             "type": "connection_established",
             "channel": "job_status",
             "message": "Connected to job status updates"
+        }))
+
+        # Send verification code
+        verification_code = ''.join(
+            random.choices(string.ascii_uppercase + string.digits, k=6)
+        )
+        await websocket.send_text(json.dumps({
+            "type": "verification",
+            "code": verification_code
         }))
         
         # Keep connection alive and handle incoming messages
@@ -161,6 +172,14 @@ async def tunnel_health_websocket(
             "channel": "tunnel_health",
             "message": "Connected to tunnel health updates"
         }))
+
+        verification_code = ''.join(
+            random.choices(string.ascii_uppercase + string.digits, k=6)
+        )
+        await websocket.send_text(json.dumps({
+            "type": "verification",
+            "code": verification_code
+        }))
         
         # Keep connection alive
         while True:
@@ -245,6 +264,14 @@ async def notifications_websocket(
             "channel": "notifications",
             "message": "Connected to system notifications"
         }))
+
+        verification_code = ''.join(
+            random.choices(string.ascii_uppercase + string.digits, k=6)
+        )
+        await websocket.send_text(json.dumps({
+            "type": "verification",
+            "code": verification_code
+        }))
         
         # Keep connection alive
         while True:
@@ -316,6 +343,14 @@ async def admin_stats_websocket(
             "user_stats": websocket_manager.get_user_stats()
         }
         await websocket.send_text(json.dumps(stats))
+
+        verification_code = ''.join(
+            random.choices(string.ascii_uppercase + string.digits, k=6)
+        )
+        await websocket.send_text(json.dumps({
+            "type": "verification",
+            "code": verification_code
+        }))
         
         # Keep connection alive
         while True:

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -44,6 +44,7 @@ import { ClusterStatsCard } from "@/components/cluster-stats-card";
 import { formatContainerName } from "@/lib/container-utils";
 import { TaskQueueDashboard } from "./components/task-queue-dashboard";
 import { DomainReadinessModal } from "@/components/domain-readiness-modal";
+import { useJobStatus } from "@/hooks/useJobStatus";
 
 // Define interface for cluster stats  
 interface ClusterStats {
@@ -143,6 +144,9 @@ export default function DashboardPage() {
   const [clusterStats, setClusterStats] = useState<ClusterStats | null>(null);
   const [jobTunnels, setJobTunnels] = useState<Record<number, TunnelData[]>>({});
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
+
+  // WebSocket connection state
+  const { isJobStatusConnected, verificationCode } = useJobStatus({ enabled: true });
   
   // Domain readiness modal states
   const [isDomainModalOpen, setIsDomainModalOpen] = useState(false);
@@ -654,6 +658,19 @@ export default function DashboardPage() {
                     Połączenie SSH: {clusterStatus.connected ? 'Aktywne' : 'Nieaktywne'}
                   </p>
                 </div>
+                <div className="flex items-center">
+                  <div className={`h-3 w-3 rounded-full mr-2 ${isJobStatusConnected ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-red-500 dark:bg-red-400'}`}></div>
+                  <p className={isJobStatusConnected ? 'text-emerald-700 dark:text-emerald-400' : 'text-red-700 dark:text-red-400 font-medium'}>
+                    Połączenie WebSocket: {isJobStatusConnected ? 'Aktywne' : 'Nieaktywne'}
+                  </p>
+                </div>
+                {verificationCode && (
+                  <div className="flex items-center">
+                    <p className="text-emerald-700 dark:text-emerald-400">
+                      Weryfikacja WebSocket: {verificationCode}
+                    </p>
+                  </div>
+                )}
                 {/* <div className="flex items-center">
                   <div className={`h-3 w-3 rounded-full mr-2 ${clusterStatus.slurm_running ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-red-500 dark:bg-red-400'}`}></div>
                   <p className={clusterStatus.slurm_running ? 'text-emerald-700 dark:text-emerald-400' : 'text-red-700 dark:text-red-400 font-medium'}>

--- a/frontend/src/hooks/useJobStatus.ts
+++ b/frontend/src/hooks/useJobStatus.ts
@@ -33,6 +33,7 @@ interface UseJobStatusReturn {
   isNotificationsConnected: boolean;
   subscribeToJob: (jobId: number) => void;
   subscribeToTunnel: (tunnelId: number) => void;
+  verificationCode: string | null;
   reconnectCounts: {
     jobStatus: number;
     tunnelHealth: number;
@@ -50,11 +51,16 @@ export const useJobStatus = ({
   // Check if user is authenticated
   const isAuthenticated = typeof window !== "undefined" && localStorage.getItem("auth_token") !== null;
 
+  const [verificationCode, setVerificationCode] = useState<string | null>(null);
+
   // Job Status WebSocket
   const handleJobMessage = useCallback((message: WebSocketMessage) => {
     console.log('Job status message:', message);
     
     switch (message.type) {
+      case 'verification':
+        setVerificationCode(message.code ?? null);
+        break;
       case 'job_status_update':
       case 'job_created':
       case 'job_deleted':
@@ -90,6 +96,9 @@ export const useJobStatus = ({
     console.log('Tunnel health message:', message);
     
     switch (message.type) {
+      case 'verification':
+        setVerificationCode(message.code ?? null);
+        break;
       case 'tunnel_created':
       case 'tunnel_active':
       case 'tunnel_failed':
@@ -132,6 +141,9 @@ export const useJobStatus = ({
     console.log('Notification message:', message);
     
     switch (message.type) {
+      case 'verification':
+        setVerificationCode(message.code ?? null);
+        break;
       case 'notification':
       case 'alert':
       case 'warning':
@@ -191,6 +203,7 @@ export const useJobStatus = ({
     isNotificationsConnected,
     subscribeToJob,
     subscribeToTunnel,
+    verificationCode,
     reconnectCounts: {
       jobStatus: jobStatusReconnectCount,
       tunnelHealth: tunnelHealthReconnectCount,


### PR DESCRIPTION
## Summary
- send short verification codes on websocket connection
- capture verification messages on the client
- display websocket status and verification code in dashboard

## Testing
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError for sqlalchemy/requests)*

------
https://chatgpt.com/codex/tasks/task_e_68829eccd0508325ba18304f1afef579