### PR TITLE
Add Caddy reverse proxy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,22 @@ services:
     depends_on:
       - backend
 
+  caddy:
+    image: caddy:2
+    container_name: containers_admin_caddy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./caddy:/etc/caddy
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile-fixed"]
+    networks:
+      - app_network
+    restart: unless-stopped
+    depends_on:
+      - backend
+      - frontend
+
 volumes:
   postgres_data2:
     name: containers_admin_postgres_data2


### PR DESCRIPTION
## Summary
- add a `caddy` service to `docker-compose.yml`
- expose ports 80 and 443
- mount `caddy/` config directory and run with provided `Caddyfile-fixed`
- depend on backend and frontend so they are proxied

## Testing
- `git ls-files '*.py' | tr '\n' '\0' | xargs -0 python -m py_compile` *(fails: SyntaxError in repo)*
- `npm test` *(fails: Missing script test)*

------
https://chatgpt.com/codex/tasks/task_e_68829ecbbb6c8325bfe516395cc009c0