### PR TITLE
Add resource usage monitoring

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -370,3 +370,27 @@ class ClusterStats(Base):
             f"gpus=free:{self.free_gpus}/busy:{self.busy_gpus}/"
             f"total:{self.total_gpus})>"
         )
+
+
+class ResourceUsageSnapshot(Base):
+    """Aggregated resource usage metrics for all users."""
+
+    __tablename__ = "resource_usage_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    timestamp = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    logged_in_users = Column(Integer, nullable=False, default=0)
+    active_containers = Column(Integer, nullable=False, default=0)
+    used_gpus = Column(Integer, nullable=False, default=0)
+    reserved_ram_gb = Column(Integer, nullable=False, default=0)
+    used_cpu_threads = Column(Integer, nullable=False, default=0)
+
+    def __repr__(self):
+        return (
+            f"<ResourceUsageSnapshot(users={self.logged_in_users}, "
+            f"containers={self.active_containers}, gpus={self.used_gpus}, "
+            f"ram_gb={self.reserved_ram_gb}, cpu_threads={self.used_cpu_threads})>"
+        )

--- a/backend/app/routers/cluster.py
+++ b/backend/app/routers/cluster.py
@@ -4,7 +4,9 @@ from typing import List
 
 from app.db.session import get_db
 from app.schemas.cluster_stats import ClusterStats, ClusterStatsCreate
+from app.schemas.resource_usage import ResourceUsage
 from app.services.cluster_stats import ClusterStatsService
+from app.services.resource_usage import ResourceUsageService
 from app.core.auth import (
     get_current_active_user_with_cli_support,
     get_current_superuser_with_cli_support,
@@ -109,3 +111,13 @@ async def test_cluster_stats_script(
         "message": "Script executed successfully",
         "data": stats_data,
     }
+
+
+@router.get("/usage/history", response_model=List[ResourceUsage])
+async def get_resource_usage_history(
+    limit: int = 2016,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user_with_cli_support),
+):
+    """Get historical resource usage snapshots."""
+    return ResourceUsageService.get_history(db, limit=limit)

--- a/backend/app/schemas/resource_usage.py
+++ b/backend/app/schemas/resource_usage.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class ResourceUsageBase(BaseModel):
+    logged_in_users: int
+    active_containers: int
+    used_gpus: int
+    reserved_ram_gb: int
+    used_cpu_threads: int
+
+
+class ResourceUsageCreate(ResourceUsageBase):
+    pass
+
+
+class ResourceUsage(ResourceUsageBase):
+    id: int
+    timestamp: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/resource_usage.py
+++ b/backend/app/services/resource_usage.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta
+from sqlalchemy.orm import Session
+
+from app.db.models import Job, ResourceUsageSnapshot
+
+
+class ResourceUsageService:
+    """Service for recording aggregated resource usage."""
+
+    @staticmethod
+    def record_snapshot(db: Session) -> ResourceUsageSnapshot:
+        active_jobs = (
+            db.query(Job)
+            .filter(Job.status.in_(["PENDING", "RUNNING", "CONFIGURING"]))
+            .all()
+        )
+
+        logged_in_users = len({job.owner_id for job in active_jobs})
+        active_containers = len(active_jobs)
+        used_gpus = sum(job.num_gpus for job in active_jobs)
+        reserved_ram_gb = sum(job.memory_gb for job in active_jobs)
+        used_cpu_threads = sum(job.num_cpus * job.num_nodes for job in active_jobs)
+
+        snapshot = ResourceUsageSnapshot(
+            logged_in_users=logged_in_users,
+            active_containers=active_containers,
+            used_gpus=used_gpus,
+            reserved_ram_gb=reserved_ram_gb,
+            used_cpu_threads=used_cpu_threads,
+        )
+
+        db.add(snapshot)
+        db.commit()
+        db.refresh(snapshot)
+
+        # Delete old records beyond 14 days
+        cutoff = datetime.utcnow() - timedelta(days=14)
+        db.query(ResourceUsageSnapshot).filter(ResourceUsageSnapshot.timestamp < cutoff).delete()
+        db.commit()
+
+        return snapshot
+
+    @staticmethod
+    def get_history(db: Session, limit: int = 2016):
+        return (
+            db.query(ResourceUsageSnapshot)
+            .order_by(ResourceUsageSnapshot.timestamp.desc())
+            .limit(limit)
+            .all()
+        )

--- a/backend/app/services/resource_usage_task.py
+++ b/backend/app/services/resource_usage_task.py
@@ -1,0 +1,55 @@
+import asyncio
+from typing import Optional
+
+from app.db.session import SessionLocal
+from app.core.logging import logger
+from app.services.resource_usage import ResourceUsageService
+
+
+class ResourceUsageTask:
+    def __init__(self, interval_minutes: int = 10):
+        self.interval_minutes = interval_minutes
+        self.interval_seconds = interval_minutes * 60
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+
+    async def start(self):
+        if self._running:
+            logger.warning("Resource usage monitoring already running")
+            return
+
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info(
+            f"Started resource usage monitoring with {self.interval_minutes} minute intervals"
+        )
+
+    async def stop(self):
+        if not self._running:
+            return
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("Stopped resource usage monitoring")
+
+    async def _loop(self):
+        while self._running:
+            try:
+                db = SessionLocal()
+                try:
+                    ResourceUsageService.record_snapshot(db)
+                finally:
+                    db.close()
+                await asyncio.sleep(self.interval_seconds)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in resource usage monitoring: {e}")
+                await asyncio.sleep(self.interval_seconds)
+
+
+resource_usage_task = ResourceUsageTask(interval_minutes=10)

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ import debugpy
 # Import cluster monitoring
 from app.services.cluster_monitoring_task import cluster_monitoring_task
 from app.services.domain_monitor import domain_monitor
+from app.services.resource_usage_task import resource_usage_task
 
 # Debug mode only for development
 
@@ -126,6 +127,10 @@ async def startup_event():
     await cluster_monitoring_task.start()
     logger.info("Background cluster monitoring started")
 
+    # Start resource usage monitoring
+    await resource_usage_task.start()
+    logger.info("Resource usage monitoring started")
+
     # Start domain monitoring
     await domain_monitor.start()
     logger.info("Background domain monitoring started")
@@ -196,6 +201,7 @@ async def shutdown_event():
 
     # Stop background services
     # await cluster_monitoring_task.stop()
+    # await resource_usage_task.stop()
     logger.info("Background cluster monitoring stopped")
 
 

--- a/frontend/src/app/dashboard/components/resource-usage-chart.tsx
+++ b/frontend/src/app/dashboard/components/resource-usage-chart.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { clusterApi } from "@/lib/api-client";
+import { ResourceUsage } from "@/lib/types";
+
+export function ResourceUsageChart() {
+  const [data, setData] = useState<ResourceUsage[]>([]);
+
+  useEffect(() => {
+    clusterApi.getUsageHistory().then((res) => {
+      setData(res.data);
+    });
+  }, []);
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle>Wykorzystanie zasobów</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={320}>
+          <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="colorContainers" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0.1} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={(value) => new Date(value).toLocaleTimeString()}
+            />
+            <YAxis />
+            <Tooltip labelFormatter={(v) => new Date(v).toLocaleString()} />
+            <Area
+              type="monotone"
+              dataKey="active_containers"
+              stroke="hsl(var(--primary))"
+              fillOpacity={1}
+              fill="url(#colorContainers)"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -41,6 +41,7 @@ import { AnimatePresence } from "framer-motion";
 import { CreateUserDialog } from "./components/create-user-dialog";
 import { EditUserDialog } from "./components/edit-user-dialog";
 import { ClusterStatsCard } from "@/components/cluster-stats-card";
+import { ResourceUsageChart } from "./components/resource-usage-chart";
 import { formatContainerName } from "@/lib/container-utils";
 import { TaskQueueDashboard } from "./components/task-queue-dashboard";
 import { DomainReadinessModal } from "@/components/domain-readiness-modal";
@@ -790,6 +791,8 @@ export default function DashboardPage() {
 
             {/* PCSS Cluster Stats Card */}
             <ClusterStatsCard onRefresh={fetchClusterStats} />
+            {/* Resource usage chart */}
+            <ResourceUsageChart />
           </div>
           
           {/* Loading state with skeleton cards only when there are no jobs yet */}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -528,8 +528,12 @@ export const clusterApi = {
   getSummary: () => apiClient.get('/cluster/stats/summary'),
   
   // Get historical cluster statistics
-  getStatsHistory: (limit?: number) => 
+  getStatsHistory: (limit?: number) =>
     apiClient.get(`/cluster/stats/history${limit ? `?limit=${limit}` : ''}`),
+
+  // Get resource usage history
+  getUsageHistory: (limit?: number) =>
+    apiClient.get(`/cluster/usage/history${limit ? `?limit=${limit}` : ''}`),
   
   // Test cluster stats script execution (admin only)
   testScript: () => apiClient.get('/cluster/stats/test-script'),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -114,3 +114,13 @@ export interface ClusterStats {
   timestamp: string;
   source?: string;
 }
+
+export interface ResourceUsage {
+  id: number;
+  timestamp: string;
+  logged_in_users: number;
+  active_containers: number;
+  used_gpus: number;
+  reserved_ram_gb: number;
+  used_cpu_threads: number;
+}


### PR DESCRIPTION
## Summary
- collect resource usage snapshots and keep last 14 days
- expose usage history API
- run a background task to store snapshots
- show new resource usage chart in dashboard

## Testing
- `pytest -q tests/test_websocket_connection.py`

------
https://chatgpt.com/codex/tasks/task_e_68833645063883258c00d8b6b1f0102e