### PR TITLE
Unify ConnectionStatus context usage

### DIFF
--- a/frontend/src/components/pcss-diagnostic-popup.tsx
+++ b/frontend/src/components/pcss-diagnostic-popup.tsx
@@ -24,14 +24,12 @@ interface PCSSDebugPopupProps {
 }
 
 export const PCSSDebugPopup = memo<PCSSDebugPopupProps>(({ isOpen, onClose }) => {
-  const { connectionStatus } = useConnectionStatusContext();
-  
-  // Use global cluster status from context - NO duplicate hooks
-  const { 
-    clusterStatus, 
-    clusterLoading: loading, 
-    clusterError: error, 
-    clusterLastUpdate: lastUpdate, 
+  const {
+    connectionStatus,
+    clusterStatus,
+    clusterLoading: loading,
+    clusterError: error,
+    clusterLastUpdate: lastUpdate,
     isClusterWebSocketActive: isWebSocketActive,
     requestClusterStatusUpdate: requestStatusUpdate
   } = useConnectionStatusContext();


### PR DESCRIPTION
## Summary
- Use a single `useConnectionStatusContext` call in PCSS diagnostic popup to destructure all needed properties at once

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894b3bd02f083258e27d26c3c1b2f1f