### PR TITLE
feat: expose manual websocket controls

### DIFF
--- a/frontend/src/hooks/useClusterStatus.ts
+++ b/frontend/src/hooks/useClusterStatus.ts
@@ -229,7 +229,7 @@ export function useClusterStatus(): UseClusterStatusReturn {
     
     console.log('[useClusterStatus] Initializing WebSocket connection - WEBSOCKET ONLY MODE');
     initialConnectionAttempted.current = true;
-    connectWebSocket();
+    // Connection is established automatically by useWebSocket
     
     // Set a timeout to show connection error only if initial connection fails after 15 seconds
     // This gives more time for the connection to establish

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -75,13 +75,13 @@ export const useWebSocket = ({
   }, [url]);
 
   const connect = useCallback(() => {
-    // Connection is managed automatically by wsManager
     console.log(`[useWebSocket] Manual connect requested for: ${url}`);
+    wsManager.forceReconnect(url);
   }, [url]);
 
   const disconnect = useCallback(() => {
-    // Individual disconnect would require unsubscribing
     console.log(`[useWebSocket] Manual disconnect requested for: ${url}`);
+    wsManager.disconnect(url);
   }, [url]);
 
   return {


### PR DESCRIPTION
## Summary
- add manual reconnect and disconnect abilities to global websocket manager
- wire useWebSocket hook's connect and disconnect to manager controls
- rely on automatic connection in useClusterStatus initialization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: see output)*

------
https://chatgpt.com/codex/tasks/task_e_6894b3bf49708325844e260f2b24434f