### PR TITLE
Handle WebSocket disconnect in cluster status loop

### DIFF
--- a/backend/app/websocket/routes.py
+++ b/backend/app/websocket/routes.py
@@ -553,6 +553,9 @@ async def cluster_status_websocket(
                     "type": "error",
                     "message": "Invalid JSON message"
                 }))
+            except WebSocketDisconnect:
+                cluster_logger.info("Cluster status WebSocket disconnected")
+                break
             except Exception as e:
                 cluster_logger.error(f"Error handling cluster status WebSocket message: {e}")
                 cluster_logger.error(f"Message was: {repr(message) if 'message' in locals() else 'no message'}")


### PR DESCRIPTION
## Summary
- handle `WebSocketDisconnect` inside cluster status WebSocket loop
- log info and break cleanly when the WebSocket disconnects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e2c7f41c83259df7c803aac1b2c8