### PR TITLE
Use normal closure code for manual WebSocket reconnect

### DIFF
--- a/frontend/src/lib/websocket-manager.ts
+++ b/frontend/src/lib/websocket-manager.ts
@@ -334,7 +334,7 @@ class WebSocketManager {
 
     connectionInfo.reconnectCount = 0;
     connectionInfo.manualClose = true;
-    connectionInfo.ws.close(1012, 'Manual reconnect');
+    connectionInfo.ws.close(1000, 'Manual reconnect');
   }
 
   /**


### PR DESCRIPTION
## Summary
- Use WebSocket close code 1000 (normal closure) when forcing reconnects

## Testing
- `npm run lint` *(fails: several ESLint errors across project)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e2c9418083258de21afffe85fd88