### PR TITLE
feat: disable optional job status channels by default

### DIFF
--- a/frontend/src/hooks/useConnectionStatus.ts
+++ b/frontend/src/hooks/useConnectionStatus.ts
@@ -103,11 +103,10 @@ export function useConnectionStatus(options: UseConnectionStatusOptions = {}): U
     isTunnelHealthConnected, 
     isNotificationsConnected, 
     verificationCode 
-  } = useJobStatus({ 
+  } = useJobStatus({
     enabled: true,
     // Tylko job status i notifications dla connection monitoring
     enableJobStatus: true,
-    enableTunnelHealth: false, // Nie potrzebne dla statusu połączenia
     enableNotifications: true
   });
   

--- a/frontend/src/hooks/useJobStatus.ts
+++ b/frontend/src/hooks/useJobStatus.ts
@@ -50,10 +50,10 @@ export const useJobStatus = ({
   onTunnelUpdate,
   onNotification,
   enabled = true,
-  // Selective enabling - domyślnie włączone dla kompatybilności wstecznej
+  // Selective enabling - only job status enabled by default for backwards compatibility
   enableJobStatus = true,
-  enableTunnelHealth = true,
-  enableNotifications = true
+  enableTunnelHealth = false,
+  enableNotifications = false
 }: UseJobStatusProps): UseJobStatusReturn => {
 
   // Check if user is authenticated


### PR DESCRIPTION
## Summary
- default tunnel health and notification channels to disabled in `useJobStatus`
- explicitly enable notifications when monitoring connection status

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689519ab7cbc83259af0944b865fc1b6