### PR TITLE
refactor: centralize cluster status context

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -46,7 +46,6 @@ import { OptimizedResourceUsageChart } from "./components/optimized-resource-usa
 import { formatContainerName } from "@/lib/container-utils";
 import { TaskQueueDashboard } from "./components/task-queue-dashboard";
 import { CodeServerModal } from "@/components/code-server-modal";
-// import { useClusterStatus } from "@/hooks/useClusterStatus"; // REMOVED - using global context
 import { useTranslation } from "@/lib/i18n/LanguageContext";
 import { ConnectionStatusCard } from "@/components/connection-status-card";
 import { useConnectionStatusContext } from "@/contexts/ConnectionStatusContext";

--- a/frontend/src/components/cluster-stats-card-new.tsx
+++ b/frontend/src/components/cluster-stats-card-new.tsx
@@ -33,7 +33,7 @@ export function ClusterStatsCard({
 }: ClusterStatsCardProps) {
   const [isDiagnosticsOpen, setIsDiagnosticsOpen] = useState(false);
   
-  // Use props data instead of calling useClusterStatus again
+  // Use props from ConnectionStatusContext instead of calling useClusterStatus directly
   const clusterStatus = propClusterStatus;
   const isLoading = propLoading;
   const error = propError;

--- a/frontend/src/components/cluster-stats-card-old.tsx
+++ b/frontend/src/components/cluster-stats-card-old.tsx
@@ -29,7 +29,7 @@ export function ClusterStatsCard({
 }: ClusterStatsCardProps) {
   const [isDiagnosticsOpen, setIsDiagnosticsOpen] = useState(false);
   
-  // Use props data instead of calling useClusterStatus again
+  // Use props from ConnectionStatusContext instead of calling useClusterStatus directly
   const clusterStatus = propClusterStatus;
   const isLoading = propLoading;
   const error = propError;

--- a/frontend/src/components/cluster-stats-card.tsx
+++ b/frontend/src/components/cluster-stats-card.tsx
@@ -41,7 +41,7 @@ export function ClusterStatsCard({
   const [isDiagnosticsOpen, setIsDiagnosticsOpen] = useState(false);
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   
-  // Use props data instead of calling useClusterStatus again
+  // Use props from ConnectionStatusContext instead of calling useClusterStatus directly
   const clusterStatus = propClusterStatus;
   const isLoading = propLoading;
   const error = propError;

--- a/frontend/src/components/pcss-diagnostic-popup.tsx
+++ b/frontend/src/components/pcss-diagnostic-popup.tsx
@@ -16,7 +16,6 @@ import {
   RefreshCcw
 } from 'lucide-react';
 import { useConnectionStatusContext } from '@/contexts/ConnectionStatusContext';
-// import { useClusterStatus } from '@/hooks/useClusterStatus'; // REMOVED - using global context
 
 interface PCSSDebugPopupProps {
   isOpen: boolean;
@@ -169,7 +168,7 @@ export const PCSSDebugPopup = memo<PCSSDebugPopupProps>(({ isOpen, onClose }) =>
               <CardContent className="space-y-2">
                 {error && (
                   <div>
-                    <span className="text-sm font-medium">Błąd useClusterStatus:</span>
+                    <span className="text-sm font-medium">Błąd statusu klastra:</span>
                     <p className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/10 p-2 rounded mt-1">
                       {error}
                     </p>
@@ -281,7 +280,7 @@ export const PCSSDebugPopup = memo<PCSSDebugPopupProps>(({ isOpen, onClose }) =>
             <CardContent>
               <pre className="text-xs bg-muted/30 p-3 rounded overflow-x-auto">
 {JSON.stringify({
-  useClusterStatus: {
+  clusterStatusContext: {
     isWebSocketActive,
     loading,
     error,


### PR DESCRIPTION
## Summary
- clean up components to rely on ConnectionStatusContext for cluster data
- rename diagnostic labels and debug info to reflect context usage
- clarify cluster stats cards consume context-provided props

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: numerous lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689519a81030832599d9540ad15a296f